### PR TITLE
Fix: not redirect to result for learned lession

### DIFF
--- a/app/controllers/lessions_controller.rb
+++ b/app/controllers/lessions_controller.rb
@@ -36,7 +36,7 @@ class LessionsController < ApplicationController
       end
     else
       flash[:warning] = "You had learned this lession!"
-      render 'show'
+      redirect_to lession_results_path @lession
     end
   end
 


### PR DESCRIPTION
When a user tries to submit answers for a learned lession, system shows
all questions with their correct answer. Should redirect to previous
result for that lession instead.