### PR TITLE
Fix: can't submit when lesson has < 20 words

### DIFF
--- a/app/views/lessons/show.html.erb
+++ b/app/views/lessons/show.html.erb
@@ -28,7 +28,7 @@
                 <%= content_tag :br %>
               <% end %>
             <% end %>
-            <% if i == 19 %>
+            <% if i == @lesson.results.count - 1 %>
               <%= button_tag "Submit", type: "submit", disabled: @lesson.learned %>
             <% else %>
               <%= button_tag "Next", type: "button", onclick: "show_questions()" %>


### PR DESCRIPTION
When user learn a category has less than 20 words, system create a
lesson with all of the word in that category but user cannot submit
their answers.